### PR TITLE
Fix canvas module not found error

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,28 @@ const nextConfig = {
       },
     ];
   },
+  webpack: (config, { isServer }) => {
+    // Handle Konva.js canvas module resolution
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        canvas: false,
+        fs: false,
+        path: false,
+        os: false,
+      };
+    }
+    
+    // Exclude canvas from client-side bundle
+    config.externals = config.externals || [];
+    if (!isServer) {
+      config.externals.push({
+        canvas: 'canvas',
+      });
+    }
+    
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5636,6 +5636,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -14907,6 +14919,7 @@
       "dependencies": {
         "@synapse/types": "file:../../shared/types",
         "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
         "helmet": "^7.1.0",
@@ -14982,6 +14995,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@synapse/types": "file:../../shared/types",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "joi": "^17.11.0",
         "pg": "^8.11.3",
@@ -15056,6 +15071,8 @@
       "dependencies": {
         "@synapse/types": "file:../../shared/types",
         "bullmq": "^4.14.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "joi": "^17.11.0",
         "pg": "^8.11.3",
@@ -15131,6 +15148,9 @@
         "@synapse/types": "file:../../shared/types",
         "axios": "^1.6.2",
         "bullmq": "^4.14.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
+        "express": "^4.18.2",
         "ioredis": "^5.3.2",
         "mongodb": "^6.3.0",
         "vm2": "^3.9.19",
@@ -15199,6 +15219,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@synapse/types": "file:../../shared/types",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "joi": "^17.11.0",
         "mongodb": "^6.3.0",


### PR DESCRIPTION
Configure Next.js webpack to exclude the `canvas` module from client-side builds, resolving 'Module not found' errors when using Konva.js.

The `canvas` package is a Node.js native module that caused "Module not found" errors when Konva.js was used in a Next.js client-side environment. This configuration tells webpack to ignore `canvas` (and other Node.js modules like `fs`, `path`, `os`) for client-side builds, allowing Konva.js to use its browser-compatible fallbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-773ccaa4-c122-48a9-b504-74e10afef36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-773ccaa4-c122-48a9-b504-74e10afef36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

